### PR TITLE
Fix Duplicate key

### DIFF
--- a/snippets/backbone.js.cson
+++ b/snippets/backbone.js.cson
@@ -208,7 +208,7 @@
     });
     """
 
-  "JavaScript: Backbone Model for CommonJS":
+  "JavaScript: Backbone Collection for CommonJS":
     "prefix": "expcollection"
     "body": """
     var _        = require("underscore");


### PR DESCRIPTION
Replace duplicate 'JavaScript: Backbone Model for CommonJS' key which prevented snippets from loading.